### PR TITLE
Add note about January 2021 fixes to jar signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This repo contains mainly [mavenized](http://maven.apache.org/) tools from the [**HD Cookbook**](http://java.net/projects/hdcookbook/) project. To build the tools, [set up](./etc/build.sh) your [*BD-J Platform Definition*](http://java.net/projects/hdcookbook/pages/BDJPlatformDefinition) and run `mvn clean install` in [`AuthoringTools`](./AuthoringTools) and [`DiscCreationTools`](./DiscCreationTools) respectively.
 
+### Fixed in 2021
+
+The JAR signer tool was not working with JDK 1.8.  This has been fixed.  Please see the
+release at https://github.com/zathras/java.net/releases/tag/1.0.1 , and the archive of the web content at https://hdcookbook.jovial.com/ 
 
 ### known issues
 * `com.hdcookbook.grin.io.xml` is broken ([compilation failure](https://gist.github.com/1916339))


### PR DESCRIPTION
This repos comes up in searches, and is fairly widely followed.  Could you add this note, please?  If you like, you're more than welcome to incorporate the JAR signer fix.  It's pretty simple - it's in the history, and I'd be happy to discuss if I could figure out your contact info :-)